### PR TITLE
docs: fix stale slug/ reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Key subpackages:
 
 - **`reporter/`** - `Reporter` interface with `TextReporter` (stderr), `JSONReporter` (stdout, JSON Lines with timestamps), `NoopReporter` (silent)
 - **`ui/`** - Console styling (`Info`/`Warn`/`Error`/`Success`), table rendering with struct tags (`table:"field,options"`), spinners, interactive prompts (`Confirm`/`Prompt`/`Option` via huh)
-- **`slug/`** - Custom `slog.Handler` implementation (forked from tint) for structured logging
+- **Logging** (`logger.go`) - `setupLogger()` configures `a.Logger` using stdlib `log/slog` with JSON or text handler based on `JSONOutput`; log level follows `Verbose`
 
 The `_examples/` directory contains demo CLI apps showing usage patterns (greet, dashboard, deploy, etc.).
 


### PR DESCRIPTION
## Summary
- `CLAUDE.md:51` listed a `slug/` subpackage that was removed in c01a8a4
- Logging is now stdlib `log/slog` wired up by `setupLogger()` in `logger.go`
- Replaced the stale bullet with one describing the actual implementation

## Test plan
- [x] Verified `slug/` is absent from the repo
- [x] Confirmed `logger.go` uses `log/slog` with JSON/Text handler selection based on `JSONOutput`

🤖 Generated with [Claude Code](https://claude.com/claude-code)